### PR TITLE
added date to notifications and fixed z index issue

### DIFF
--- a/src/app/components/admin-reviews/reviews-table/reviews-table.component.html
+++ b/src/app/components/admin-reviews/reviews-table/reviews-table.component.html
@@ -1,6 +1,6 @@
 <div class="grid">
     <div class="col-12">
-      <p-toast position="top-right"></p-toast>
+      <p-toast position="top-right" [baseZIndex]="20000" [autoZIndex]="true"></p-toast>
       
       <div class="card">
         <p-table

--- a/src/app/components/admin-reviews/reviews-table/reviews-table.component.ts
+++ b/src/app/components/admin-reviews/reviews-table/reviews-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -24,6 +24,7 @@ import { ReviewService } from '../review-service.service';
 @Component({
   selector: 'app-reviews-table',
   templateUrl: './reviews-table.component.html',
+  styleUrl:'./reviews-table.component.scss',
   standalone: true,
   imports: [
     CommonModule,
@@ -38,7 +39,8 @@ import { ReviewService } from '../review-service.service';
     ConfirmDialogModule,
     TooltipModule
   ],
-  providers: [MessageService, ConfirmationService]
+  providers: [MessageService, ConfirmationService],
+  encapsulation:ViewEncapsulation.None
 })
 export class ReviewsTableComponent implements OnInit {
   reviews: ReviewOverviewDTO[] = [];

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,3 +1,3 @@
 .headercomponent{
-    z-index: 2000;
+    z-index: 1001;
 }

--- a/src/app/components/sidebar-notifications/notification-dto.ts
+++ b/src/app/components/sidebar-notifications/notification-dto.ts
@@ -2,4 +2,5 @@ export interface NotificationDTO {
     id?: number;
     content: string;
     read: boolean;
+    date:Date;
 }

--- a/src/app/components/sidebar-notifications/notification.service.ts
+++ b/src/app/components/sidebar-notifications/notification.service.ts
@@ -1,8 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { NotificationDTO } from './notification-dto';
 import { API_URL } from '../../../globals';
+import { JwtService } from '../auth/jwt.service';
 
 @Injectable({
   providedIn: 'root'
@@ -10,17 +11,21 @@ import { API_URL } from '../../../globals';
 export class NotificationService {
   private baseUrl = `${API_URL}/api/v1/notifications`;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private jwtService: JwtService) { }
 
-  getUnreadNotifications(userId: number): Observable<NotificationDTO[]> {
-      return this.http.get<NotificationDTO[]>(`${this.baseUrl}/unread/${userId}`);
+  getUnreadNotifications(): Observable<NotificationDTO[]> {
+    const userId = this.jwtService.getIdFromToken();
+    if (userId === -1) return of([]);
+    return this.http.get<NotificationDTO[]>(`${this.baseUrl}/unread/${userId}`);
   }
 
-  getReadNotifications(userId: number): Observable<NotificationDTO[]> {
-      return this.http.get<NotificationDTO[]>(`${this.baseUrl}/read/${userId}`);
+  getReadNotifications(): Observable<NotificationDTO[]> {
+    const userId = this.jwtService.getIdFromToken();
+    if (userId === -1) return of([]);
+    return this.http.get<NotificationDTO[]>(`${this.baseUrl}/read/${userId}`);
   }
 
   markAsRead(notificationId: number): Observable<void> {
-      return this.http.put<void>(`${this.baseUrl}/${notificationId}/read`, {});
+    return this.http.put<void>(`${this.baseUrl}/${notificationId}/read`, {});
   }
 }

--- a/src/app/components/sidebar-notifications/sidebar-notifications.component.html
+++ b/src/app/components/sidebar-notifications/sidebar-notifications.component.html
@@ -8,10 +8,10 @@
                         styleClass="mb-3">
                     <div class="flex justify-content-between align-items-start">
                         <div class="notification-content">
-                            <p>{{notification.content}}</p>
-                            <!-- <small class="text-500">
-                                {{notification.timestamp | date:'short'}}
-                            </small> -->
+                            <p style="white-space: pre-line;">{{notification.content}}</p>
+                            <small class="text-500">
+                                {{notification.date | date:'dd/MM/yyyy HH:mm'}}
+                            </small>
                         </div>
                         <p-button
                                 icon="pi pi-times" 
@@ -32,10 +32,10 @@
                 <p-card *ngFor="let notification of readNotifications" 
                         styleClass="mb-3">
                     <div class="notification-content">
-                        <p>{{notification.content}}</p>
-                        <!-- <small class="text-500">
-                            {{notification.timestamp | date:'short'}}
-                        </small> -->
+                        <p style="white-space: pre-line;">{{notification.content}}</p>
+                        <small class="text-500">
+                            {{notification.date | date:'dd/MM/yyyy HH:mm'}}
+                        </small>
                     </div>
                 </p-card>
                 <div *ngIf="readNotifications.length === 0" 

--- a/src/app/components/sidebar-notifications/sidebar-notifications.component.ts
+++ b/src/app/components/sidebar-notifications/sidebar-notifications.component.ts
@@ -17,7 +17,6 @@ export class SidebarNotificationsComponent {
   activeTab: number = 0;
   unreadNotifications: NotificationDTO[] = [];
   readNotifications: NotificationDTO[] = [];
-  userId: number = 1; // This should be obtained from your auth service
 
   constructor(private notificationService: NotificationService) { }
 
@@ -26,12 +25,12 @@ export class SidebarNotificationsComponent {
   }
 
   loadNotifications() {
-    this.notificationService.getUnreadNotifications(this.userId)
+    this.notificationService.getUnreadNotifications()
       .subscribe(notifications => {
         this.unreadNotifications = notifications;
       });
 
-    this.notificationService.getReadNotifications(this.userId)
+    this.notificationService.getReadNotifications()
       .subscribe(notifications => {
         this.readNotifications = notifications;
       });


### PR DESCRIPTION
# Fixed Notification Display Issues

## Changes
- Added timestamp display to notifications
- Fixed z-index layering for toast notifications
- Updated notification text formatting to properly display newlines

## Technical Details
- Added date pipe to format notification timestamps in the notification component
- Configured PrimeNG toast z-index through baseZIndex property to ensure proper layering
- Set white-space CSS property to preserve newline formatting in notification content

## Testing
- Verified notifications display timestamps correctly
- Confirmed toast notifications appear above other UI elements
- Tested notification text formatting with multi-line content