### PR TITLE
Set up WebSocket for private chats

### DIFF
--- a/src/app/components/user/user.service.ts
+++ b/src/app/components/user/user.service.ts
@@ -22,20 +22,6 @@ export class UserService {
     return this.httpClient.post<any>(`${API_URL}/api/v1/users/follow-event`, null, { params: params });
   }
 
-  getServiceProvidersForOrganizerEvents(organizerId: number,role:string): Observable<UserOverviewDTO[]> {
-    console.log(`userId: ${organizerId}, role: ${role}`);
-    if (organizerId === -1)
-      return of([]);
-    if(role==='EO')
-      return this.httpClient.get<UserOverviewDTO[]>(`${API_URL}/api/v1/users/eo/${organizerId}/chat-users`);
-
-    else if(role==='SP')
-      return this.httpClient.get<UserOverviewDTO[]>(`${API_URL}/api/v1/users/sp/${organizerId}/chat-users`);
-
-    else
-      return this.httpClient.get<UserOverviewDTO[]>(`${API_URL}/api/v1/users/au/chat-users`);
-  }
-
   getServiceProviderById(id: number): Observable<UserOverviewDTO> {
     return this.httpClient.get<UserOverviewDTO>(`${API_URL}/api/v1/users/sp/${id}/message`);
   }


### PR DESCRIPTION
Fixed WebSocket integration to ensure messages are exchanged exclusively between two users. 

Previously, messages were being broadcasted to all connected users, leading to incorrect behavior where multiple users could see the same messages in a chat.

In this update:
- Implemented private chat channels using user-specific topics.
- Each conversation is now subscribed to a unique topic based on the sender and recipient IDs.
- WebSocket connections are properly managed by ensuring that previous subscriptions are unsubscribed before creating new ones, preventing multiple active connections for the same user.
- Messages are now correctly routed between the sender and recipient without interference from other users.

This ensures that messages are securely exchanged only between the intended users, improving chat functionality and privacy.